### PR TITLE
Friday Update 3

### DIFF
--- a/ChecksFile.wl
+++ b/ChecksFile.wl
@@ -181,18 +181,18 @@ Idis[data_,\[CapitalOmega]_,k_,En_,n_,xflavor_]:=Module[{cos\[Theta],\[Phi]0,\[P
 
 cos\[Theta]=data["mids"];
 {\[CapitalOmega]p,kp,\[Omega]}=IdisShifts[data,\[CapitalOmega],k,En,xflavor];
-\[CapitalOmega]minuskpcos\[Theta][i_]:=IdisBottom[data,\[CapitalOmega],k,En,xflavor][[i]];
+\[CapitalOmega]minuskpcos\[Theta]=Reap[Do[Sow[IdisBottom[data,\[CapitalOmega],k,En,xflavor][[i]]],{i,1,Length[cos\[Theta]]}]][[2,1]];
 
 (* neutrino number densities disguised as SI potentials *)
-mu[i_]:=   munits ndensities[data,"xflavor"->xflavor][[1,i,i]];
-mubar[i_]:=munits ndensities[data,"xflavor"->xflavor][[2,i,i]];
+mu=Reap[Do[Sow[munits ndensities[data,"xflavor"->xflavor][[1,i,i]]],{i,1,Length[cos\[Theta]]}]][[2,1]];
+mubar=Reap[Do[Sow[munits ndensities[data,"xflavor"->xflavor][[2,i,i]]],{i,1,Length[cos\[Theta]]}]][[2,1]];
 
 (* make sure the denominator is not tiny *)
 (*On[Assert];
 Do[Assert[(\[CapitalOmega]p-(kp cos\[Theta][[i]]))/(\[CapitalOmega]p+(kp cos\[Theta][[i]]))>= 1,"\[CapitalOmega]p' k'Cos[\[Theta]] percent difference less than 1"],{i,1,Length[cos\[Theta]]}]; 
 *)
 (*Definition of I from Gail's equation (41)*)
-result= Sum[cos\[Theta][[i]]^n (((mu[i]-mubar[i])\[CapitalOmega]minuskpcos\[Theta][i]) + (mu[i]+mubar[i])\[Omega]) / (\[CapitalOmega]minuskpcos\[Theta][i]^2-\[Omega]^2) ,{i,1,Length[cos\[Theta]]}];
+result= Sum[cos\[Theta][[i]]^n (((mu[[i]]-mubar[[i]])\[CapitalOmega]minuskpcos\[Theta][[i]]) + (mu[[i]]+mubar[[i]])\[Omega]) / (\[CapitalOmega]minuskpcos\[Theta][[i]]^2-\[Omega]^2) ,{i,1,Length[cos\[Theta]]}];
 Return[result];
 ];
 

--- a/ChecksFile.wl
+++ b/ChecksFile.wl
@@ -170,8 +170,8 @@ Return[{\[CapitalOmega]p,kp,\[Omega]}];
 IdisBottom[data_,\[CapitalOmega]_,k_,En_,xflavor_]:=Module[{cos\[Theta],\[Phi]0,\[Phi]1,\[CapitalOmega]p,kp,\[Omega],mu,mubar,Vmatter,\[CapitalOmega]minuskpcos\[Theta],result,bottom},
 cos\[Theta]=data["mids"];
 {\[CapitalOmega]p,kp,\[Omega]}=IdisShifts[data,\[CapitalOmega],k,En,xflavor];
-bottom[i_]:=\[CapitalOmega]p-kp cos\[Theta][[i]];
-Return[Table[bottom[i],{i,1,Length[cos\[Theta]]}]];
+bottom=Reap[Do[Sow[\[CapitalOmega]p-kp cos\[Theta][[i]]],{i,1,Length[cos\[Theta]]}]][[2,1]];
+Return[bottom];
 ]
 
 

--- a/ChecksFile.wl
+++ b/ChecksFile.wl
@@ -143,12 +143,12 @@ Idis\[Phi]s[data_,xflavor_]:=Module[{cos\[Theta],\[Phi]0,\[Phi]1,mu,mubar},
 cos\[Theta]=data["mids"];
 
 (* neutrino number densities disguised as SI potentials *)
-mu[i_]:=   munits ndensities[data,"xflavor"->xflavor][[1,i,i]];
-mubar[i_]:=munits ndensities[data,"xflavor"->xflavor][[2,i,i]];
+mu=Reap[Do[Sow[munits ndensities[data,"xflavor"->xflavor][[1,i,i]]],{i,1,Length[cos\[Theta]]}]][[2,1]];
+mubar=Reap[Do[Sow[munits ndensities[data,"xflavor"->xflavor][[2,i,i]]],{i,1,Length[cos\[Theta]]}]][[2,1]];
 
 (*Defined in Gail's Blue equation 30 and 31 *)
-\[Phi]0 = Sum[(mu[i]-mubar[i])         ,{i,1,Length[cos\[Theta]]}];
-\[Phi]1 = Sum[(mu[i]-mubar[i])cos\[Theta][[i]],{i,1,Length[cos\[Theta]]}];
+\[Phi]0 = Sum[(mu[[i]]-mubar[[i]])         ,{i,1,Length[cos\[Theta]]}];
+\[Phi]1 = Sum[(mu[[i]]-mubar[[i]])cos\[Theta][[i]],{i,1,Length[cos\[Theta]]}];
 
 Return[{\[Phi]0,\[Phi]1}];
 ]
@@ -314,7 +314,7 @@ Return[ellipsefiterrors[moms[[1]],moms[[2]]//Abs,moms[[3]]]]
 
 
  tr=TestReport["testfiles.wlt"]
-Table[tr["TestResults"][i],{i,1,9}]//MatrixForm
+Table[tr["TestResults"][i],{i,1,12}]//MatrixForm
 
 
 

--- a/testfiles.wlt
+++ b/testfiles.wlt
@@ -57,7 +57,7 @@ VerificationTest[(* 7 *)
 ]
 
 VerificationTest[(* 8 *)
-	Part[realdatadispersioncheck[StringJoin[inpath, "112Msun_100ms_DO.h5"], "112Msun_100ms_r200_r300_now_nox.h5", 250], 1]
+	realdatadispersioncheck[StringJoin[inpath, "112Msun_100ms_DO.h5"], "112Msun_100ms_r200_r300_now_nox.h5", 250]
 	,
 	True	
 	,
@@ -65,7 +65,7 @@ VerificationTest[(* 8 *)
 ]
 
 VerificationTest[(* 9 *)
-	Part[realdatadispersioncheck[StringJoin[inpath, "112Msun_100ms_DO.h5"], "112Msun_100ms_r200_r300_nox.h5", 250], 1]
+	realdatadispersioncheck[StringJoin[inpath, "112Msun_100ms_DO.h5"], "112Msun_100ms_r200_r300_nox.h5", 250]
 	,
 	True	
 	,

--- a/testfiles.wlt
+++ b/testfiles.wlt
@@ -57,7 +57,7 @@ VerificationTest[(* 7 *)
 ]
 
 VerificationTest[(* 8 *)
-	realdatadispersioncheck[StringJoin[inpath, "112Msun_100ms_DO.h5"], "112Msun_100ms_r200_r300_now_nox.h5", 250]
+	Part[realdatadispersioncheck[StringJoin[inpath, "112Msun_100ms_DO.h5"], "112Msun_100ms_r200_r300_now_nox.h5", 250], 1]
 	,
 	True	
 	,
@@ -65,11 +65,11 @@ VerificationTest[(* 8 *)
 ]
 
 VerificationTest[(* 9 *)
-	realdatadispersioncheck[StringJoin[inpath, "112Msun_100ms_DO.h5"], "112Msun_100ms_r200_r300_nox.h5", 250]
+	Part[realdatadispersioncheck[StringJoin[inpath, "112Msun_100ms_DO.h5"], "112Msun_100ms_r200_r300_nox.h5", 250], 1]
 	,
 	True	
 	,
-	{TestID-> "Real data Dispersion Check; \[Omega]!=0, no x flavor"}
+	TestID-> "Real data Dispersion Check; \[Omega]!=0, no x flavor"
 ]
 
 VerificationTest[(* 10 *)
@@ -85,7 +85,7 @@ VerificationTest[(* 11 *)
 	,
 	True
 	,
-	{Assert::asrtfl, FindRoot::jsing, Assert::asrtfl, FindRoot::jsing, Assert::asrtfl, General::stop, FindRoot::jsing, General::stop}
+	{FindRoot::jsing, FindRoot::jsing, FindRoot::jsing, General::stop}
 	,
 	TestID-> "Ellipse Fitting: Check ellipse fit error in moments for CSSN data"
 ]


### PR DESCRIPTION
Speed Improvements: Got rid of the functional forms in modules, both the ones you put in and the ones I put in. Increases the speed to about a minute per eigenvalue.  Not sure what else can be done

Testing format: Instead of trying to bounce a list of messages into the .wlt file, I changed the output of the realdatadispcalc to pass the tested eigenvalues.  Then, in realdatadispcheck, it calculates a list of passes/fails for the .wlt file check, as usual, but also calculates a list of how each eigenvalue passes. If the test fails (without messages), this table could be incorrect (I wrote the logic assuming either the test passes naturally (Idis=0) or conditionally (Idis not 0, but percent difference is very small).

Test Results: At the bottom, in addition to the test report, I have it print out the regression test plots.  Additionally, it calculates two real data dispersion checks and makes a table showing, for each eigenvalue, whether it passes naturally (true) or conditionally (false).  The eigenvalues tested currently look the same because it's only showing a few digits.  Might be necessary to expand it some.

Documentation: I added in some comments into these functions to make them easier to parse.